### PR TITLE
Update Qt-related imports

### DIFF
--- a/glue_openspace/__init__.py
+++ b/glue_openspace/__init__.py
@@ -10,5 +10,5 @@ except DistributionNotFound:
 
 def setup():
     from .viewer import OpenSpaceDataViewer
-    from glue.config import qt_client
+    from glue_qt.config import qt_client
     qt_client.add(OpenSpaceDataViewer)

--- a/glue_openspace/layer_state_widget.py
+++ b/glue_openspace/layer_state_widget.py
@@ -4,8 +4,8 @@ import os
 
 from qtpy import QtWidgets
 
-from glue.external.echo.qt import autoconnect_callbacks_to_qt
-from glue.utils.qt import load_ui, fix_tab_widget_fontsize
+from echo.qt import autoconnect_callbacks_to_qt
+from glue_qt.utils import load_ui, fix_tab_widget_fontsize
 
 __all__ = ['OpenSpaceLayerStateWidget']
 

--- a/glue_openspace/layer_state_widget.ui
+++ b/glue_openspace/layer_state_widget.ui
@@ -88,7 +88,7 @@
           <item>
            <widget class="QComboBox" name="combosel_size_att">
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
            </widget>
           </item>
@@ -240,7 +240,7 @@
           <item>
            <widget class="QComboBox" name="combosel_cmap_att">
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
            </widget>
           </item>
@@ -326,7 +326,7 @@
           <item>
            <widget class="QColormapCombo" name="combodata_cmap">
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
            </widget>
           </item>
@@ -416,12 +416,12 @@
   <customwidget>
    <class>QColorBox</class>
    <extends>QLabel</extends>
-   <header>glue.utils.qt.colors</header>
+   <header>glue_qt.utils.colors</header>
   </customwidget>
   <customwidget>
    <class>QColormapCombo</class>
    <extends>QComboBox</extends>
-   <header>glue.utils.qt.colors</header>
+   <header>glue_qt.utils.colors</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/glue_openspace/tests/test_viewer.py
+++ b/glue_openspace/tests/test_viewer.py
@@ -2,7 +2,7 @@ import pytest
 from mock import patch
 
 from glue.core import Data
-from glue.app.qt import GlueApplication
+from glue_qt.app import GlueApplication
 from glue_openspace.viewer import OpenSpaceDataViewer
 
 

--- a/glue_openspace/viewer.py
+++ b/glue_openspace/viewer.py
@@ -4,8 +4,8 @@ from qtpy.QtWidgets import QLabel, QLineEdit, QHBoxLayout, QVBoxLayout, QPushBut
 from qtpy.QtGui import QImage, QPixmap
 from qtpy.QtCore import Qt
 
-from glue.viewers.common.qt.data_viewer import DataViewer
-from glue.utils.qt import messagebox_on_error
+from glue_qt.viewers.common.data_viewer import DataViewer
+from glue_qt.utils import messagebox_on_error
 
 from websocket import create_connection
 

--- a/glue_openspace/viewer_state_widget.py
+++ b/glue_openspace/viewer_state_widget.py
@@ -2,8 +2,8 @@ import os
 
 from qtpy.QtWidgets import QWidget
 
-from glue.external.echo.qt import autoconnect_callbacks_to_qt
-from glue.utils.qt import load_ui
+from echo.qt import autoconnect_callbacks_to_qt
+from glue_qt.utils import load_ui
 from .viewer_state import MODES_BODIES
 
 __all__ = ['OpenSpaceViewerStateWidget']

--- a/glue_openspace/viewer_state_widget.ui
+++ b/glue_openspace/viewer_state_widget.ui
@@ -39,7 +39,7 @@
    <item row="2" column="1">
     <widget class="QComboBox" name="combosel_lon_att">
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
@@ -73,14 +73,14 @@
    <item row="1" column="1">
     <widget class="QComboBox" name="combosel_frame">
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
    <item row="3" column="1">
     <widget class="QComboBox" name="combosel_lat_att">
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
@@ -110,14 +110,14 @@
    <item row="0" column="1">
     <widget class="QComboBox" name="combosel_mode">
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
    <item row="5" column="1">
     <widget class="QComboBox" name="combosel_alt_unit">
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,8 @@ packages = find:
 setup_requires = setuptools_scm
 install_requires =
     numpy
-    glue-core>=0.15
+    glue-core>=1.13.1
+    glue-qt
     qtpy
     astropy
     matplotlib


### PR DESCRIPTION
Currently this plugin is written expecting all of glue's Qt functionality to still be in the core package, which is no longer the case. This PR updates Qt-based imports to use `glue_qt` instead. I also 

I think this should be all we need to do, but I wasn't able to verify - when I connected to OpenSpace, it seemed to have an issue sending the data - I got an error message inside OpenSpace that the class `RenderableBillboardsCloud` couldn't be found. @micahnyc does this work for you? (also, have you ever seen this error before?)